### PR TITLE
Change createOutput to static function.

### DIFF
--- a/src/OutputFactory.php
+++ b/src/OutputFactory.php
@@ -22,7 +22,7 @@ class OutputFactory {
    * @return \Symfony\Component\Console\Output\ConsoleOutput
    *   The ConsoleOutput with full formatter styling applied.
    */
-  public function createOutput(EventDispatcherInterface $dispatcher) {
+  public static function createOutput(EventDispatcherInterface $dispatcher) {
     $event = new OutputFormatterStyleEvent();
     $dispatcher->dispatch(CommonConsoleEvents::OUTPUT_FORMATTER_STYLE, $event);
     $output = new ConsoleOutput();


### PR DESCRIPTION
Deprecation errors were thrown when the container calls the factory method contaminating the output stream.